### PR TITLE
Fix steampack and gun projectile positions

### DIFF
--- a/Base/EntityAnimated.GetPointOnSlotAtRelativePosition().cs
+++ b/Base/EntityAnimated.GetPointOnSlotAtRelativePosition().cs
@@ -1,0 +1,7 @@
+public Vector2 GetPointOnSlotAtRelativePosition(string slotName, Vector2 relativePosition) {
+    float[] slotVertices = this.GetSlotVertices(slotName);
+    Vector2 p0 = new Vector2(slotVertices[6], slotVertices[7]);
+    Vector2 px = new Vector2(slotVertices[0], slotVertices[1]);
+    Vector2 py = new Vector2(slotVertices[4], slotVertices[5]);
+    return p0 + relativePosition.x * (px - p0) + relativePosition.y * (py - p0);
+}

--- a/Base/EntityAnimated.GetSlotVertices().cs
+++ b/Base/EntityAnimated.GetSlotVertices().cs
@@ -1,0 +1,19 @@
+protected float[] GetSlotVertices(string slotName) {
+	Slot slot = this.skeleton.skeleton.FindSlot(slotName);
+	float[] array = new float[8];
+	if (slot != null) {
+		RegionAttachment regionAttachment = (RegionAttachment)slot.Attachment;
+		if (regionAttachment != null) {
+			regionAttachment.ComputeWorldVertices(0f, 0f, slot.bone, array);
+			Quaternion rotation = this.skeletonTransform.localRotation;
+			for (int i = 0; i < 8; i += 2) {
+				float offsetX = array[i];
+				float offsetY = array[i + 1];
+				Vector3 offset = rotation * new Vector3(offsetX, offsetY);
+				array[i] = base.transform.position.x + offset.x;
+				array[i + 1] = base.transform.position.y + offset.y;
+			}
+		}
+	}
+	return array;
+}

--- a/Base/EntityAnimated.GetSlotVertices().cs
+++ b/Base/EntityAnimated.GetSlotVertices().cs
@@ -6,12 +6,17 @@ protected float[] GetSlotVertices(string slotName) {
 		if (regionAttachment != null) {
 			regionAttachment.ComputeWorldVertices(0f, 0f, slot.bone, array);
 			Quaternion rotation = this.skeletonTransform.localRotation;
+			// There seems to be an offset in the skeleton position relative to the entity.
+			// This is more prominent for players other than the currently playing player.
+			// Skeleton is 0.09997559 too high for the current player and 0.9885864 for other players.
+			// For simplicity we consider the current player to be properly aligned so we use the difference.
+			float yAdjustment = this.isPlayer ? 0.0f : -0.88861081f;
 			for (int i = 0; i < 8; i += 2) {
 				float offsetX = array[i];
 				float offsetY = array[i + 1];
 				Vector3 offset = rotation * new Vector3(offsetX, offsetY);
 				array[i] = base.transform.position.x + offset.x;
-				array[i + 1] = base.transform.position.y + offset.y;
+				array[i + 1] = base.transform.position.y + yAdjustment + offset.y;
 			}
 		}
 	}

--- a/Base/EntityAvatar.EmitSteampackParticles().cs
+++ b/Base/EntityAvatar.EmitSteampackParticles().cs
@@ -11,12 +11,7 @@ private void EmitSteampackParticles() {
     }
     
     if (this.emitter != null && Time.time - this.lastSteamParticleAt > 1f / this.steamRate) {
-        Vector2 emitterPosition = this.steampackItem.emitterPosition;
-        float[] slotVertices = base.GetSlotVertices("suit");
-        Vector2 p0 = new Vector2(slotVertices[6], slotVertices[7]);
-        Vector2 px = new Vector2(slotVertices[0], slotVertices[1]);
-        Vector2 py = new Vector2(slotVertices[4], slotVertices[5]);
-        Vector2 pointOnSlot = p0 + emitterPosition.x * (px - p0) + emitterPosition.y * (py - p0);
+        Vector2 pointOnSlot = base.GetPointOnSlotAtRelativePosition("suit", this.steampackItem.emitterPosition);
         this.emitter.Spawn(pointOnSlot.x, pointOnSlot.y, 1);
         this.lastSteamParticleAt = Time.time;
     }

--- a/Base/EntityAvatar.EmitSteampackParticles().cs
+++ b/Base/EntityAvatar.EmitSteampackParticles().cs
@@ -1,0 +1,23 @@
+private void EmitSteampackParticles() {
+    if (this.isPlayer && ReplaceableSingleton<Player>.main.suppressed) {
+        return;
+    }
+
+    if (this.steampackItem == null) {
+        if (this.isPlayer) {
+            return;
+        }
+        this.steampackItem = Item.Get("accessories/jetpack");
+    }
+    
+    if (this.emitter != null && Time.time - this.lastSteamParticleAt > 1f / this.steamRate) {
+        Vector2 emitterPosition = this.steampackItem.emitterPosition;
+        float[] slotVertices = base.GetSlotVertices("suit");
+        Vector2 p0 = new Vector2(slotVertices[6], slotVertices[7]);
+        Vector2 px = new Vector2(slotVertices[0], slotVertices[1]);
+        Vector2 py = new Vector2(slotVertices[4], slotVertices[5]);
+        Vector2 pointOnSlot = p0 + emitterPosition.x * (px - p0) + emitterPosition.y * (py - p0);
+        this.emitter.Spawn(pointOnSlot.x, pointOnSlot.y, 1);
+        this.lastSteamParticleAt = Time.time;
+    }
+}

--- a/Base/EntityHuman.ShootGun().cs
+++ b/Base/EntityHuman.ShootGun().cs
@@ -1,0 +1,38 @@
+public Entity ShootGun(Item item, Vector2 pt, bool burst = true) {
+    this.AnimateEye("angry", 1f);
+    EntityConfig entityConfig = Config.main.entitiesByName.Get(item.spawn);
+    if (entityConfig != null) {
+        this.lastShootAt = Time.time;
+        float num = Mathf.Lerp(0.5f, 0f, (!this.isPlayer) ? 0f : ReplaceableSingleton<Player>.main.AimSteadiness());
+        pt.x += global::UnityEngine.Random.Range(-num, num);
+        pt.y += global::UnityEngine.Random.Range(-num, num);
+        EntityBullet entityBullet = Singleton<EntityBulletPool>.main.Spawn();
+        if (entityBullet != null) {
+            entityBullet.config = entityConfig;
+            entityBullet.item = item;
+            entityBullet.local = true;
+            entityBullet.parentEntity = this;
+            entityBullet.isPlayerBullet = this.isPlayer;
+            entityBullet.canHurtPlayer = this.CanShootPlayer();
+            entityBullet.Begin(null);
+            EntitySlotRelativePositionSender entitySender = new EntitySlotRelativePositionSender(this, item.emitterPosition, (!this.IsVisible()) ? null : "tool-end");
+            PositionReceiver positionReceiver = new PositionReceiver(pt);
+            positionReceiver.TargetProjectile(entityBullet, entitySender, null, item.speed);
+            float armWorldDirection = pt.x <= base.cTransform.position.x ? (this.toolArmBone.rotation + 180f) : (360f - this.toolArmBone.rotation);
+            if (item.shootEmitter != null) {
+                item.shootEmitter.angleBase = -armWorldDirection;
+                Vector2 pointOnSlot = base.GetPointOnSlotAtRelativePosition("tool-end", item.emitterPosition);
+                item.shootEmitter.Spawn(pointOnSlot.x, pointOnSlot.y, global::UnityEngine.Random.Range(3, 6));
+            }
+            base.SetSlotOpacity("tool-end", (item.rate <= 10f) ? 1f : global::UnityEngine.Random.Range(0.2f, 0.8f));
+            if (burst && item.burst > 0) {
+                base.StartCoroutine(this.ShootBurst(item, pt, item.burst, 0.03f));
+            }
+            if (item.soundLoop != null) {
+                this.soundSource.Loop("weapon", SoundSource.GroupClip(item.soundLoop), 0.5f, Time.deltaTime * 10f);
+            }
+            return entityBullet;
+        }
+    }
+    return null;
+}

--- a/Base/Item.Item().cs
+++ b/Base/Item.Item().cs
@@ -3,4 +3,11 @@
 		this.scrubbable = base.ConfigBool("scrubbable", false);
 		this.jiggle = base.ConfigFloat("jiggle", 0.0f);
 
+		List<object> emitterPosition = (List<object>)this.data.Get("emitter_position");
+		if (emitterPosition != null) {
+			this.emitterPosition = new Vector3((float)emitterPosition[0], (float)emitterPosition[1]);
+		} else {
+			this.emitterPosition = new Vector3(0.5f, -0.2f);
+		}
+
 ...

--- a/Base/Item.Item().cs
+++ b/Base/Item.Item().cs
@@ -7,7 +7,7 @@
 		if (emitterPosition != null) {
 			this.emitterPosition = new Vector3((float)emitterPosition[0], (float)emitterPosition[1]);
 		} else {
-			this.emitterPosition = new Vector3(0.5f, -0.2f);
+			this.emitterPosition = new Vector3(0.5f, -0.4f);
 		}
 
 ...

--- a/Base/Item.Item().cs
+++ b/Base/Item.Item().cs
@@ -1,13 +1,17 @@
 ...
 
-		this.scrubbable = base.ConfigBool("scrubbable", false);
-		this.jiggle = base.ConfigFloat("jiggle", 0.0f);
+        this.scrubbable = base.ConfigBool("scrubbable", false);
+        this.jiggle = base.ConfigFloat("jiggle", 0.0f);
 
-		List<object> emitterPosition = (List<object>)this.data.Get("emitter_position");
-		if (emitterPosition != null) {
-			this.emitterPosition = new Vector3((float)emitterPosition[0], (float)emitterPosition[1]);
-		} else {
-			this.emitterPosition = new Vector3(0.5f, -0.4f);
-		}
+        List<object> emitterPosition = (List<object>)this.data.Get("emitter_position");
+        if (emitterPosition != null) {
+            this.emitterPosition = new Vector3((float)emitterPosition[0], (float)emitterPosition[1]);
+        } else {
+            if ("gun" == base.ConfigString("action")?.ToLower()) {
+                this.emitterPosition = new Vector3(0.5f, 0.0f);
+            } else {
+                this.emitterPosition = new Vector3(0.5f, -0.4f);
+            }
+        }
 
 ...

--- a/Base/Item.emitterPosition.cs
+++ b/Base/Item.emitterPosition.cs
@@ -1,0 +1,1 @@
+public Vector2 emitterPosition;

--- a/Target/EntitySenderWithRelativePosition.cs
+++ b/Target/EntitySenderWithRelativePosition.cs
@@ -1,0 +1,38 @@
+public class EntitySlotRelativePositionSender : EntityTargeter, Sender {
+    public EntitySlotRelativePositionSender(int entityId)
+        : base(entityId) {
+        this.slotRelativePosition = new Vector2(0.5f, 0);
+    }
+
+    public EntitySlotRelativePositionSender(Entity entity, Vector2 slotRelativePosition, string slot = null)
+        : base(entity, slot) {
+        this.slotRelativePosition = slotRelativePosition;
+    }
+
+    public Vector2 Origin(Dictionary<string, object> details) {
+        if (!this.entity.IsVisible()) {
+            if (this.entity.isBlock) {
+                return this.entity.Center();
+            }
+            return this.entity.cTransform.position;
+        } else {
+            if (this.slot == null) {
+                object[] array = (object[])details.Get("sl");
+                if (array != null) {
+                    int num = Convert.ToInt32(array[0]);
+                    this.slot = ((EntityAnimated)this.entity).GetConfigSlot(num);
+                }
+            }
+            if (this.entity is EntityAnimated && this.slot != null) {
+                return ((EntityAnimated)this.entity).GetPointOnSlotAtRelativePosition(this.slot, this.slotRelativePosition);
+            }
+            return this.entity.Center();
+        }
+    }
+
+    public override bool Valid() {
+        return this.entity != null;
+    }
+
+    private Vector2 slotRelativePosition;
+}


### PR DESCRIPTION
- Use `skeletonTransform.localRotation` and `entity.transform.position` instead of `renderer.bounds`.
- Make steampack emitter position configurable per item - It currently can't handle the config key `emitter position` please check.