### PR TITLE
Admin-Only Lighting Commands

### DIFF
--- a/Base/LightingConsoleCommand.RequiresAdmin().cs
+++ b/Base/LightingConsoleCommand.RequiresAdmin().cs
@@ -1,0 +1,3 @@
+public override bool RequiresAdmin() {
+    return true;
+}

--- a/Base/MoodyConsoleCommand.cs
+++ b/Base/MoodyConsoleCommand.cs
@@ -5,7 +5,16 @@ public class MoodyConsoleCommand : ConsoleCommand {
 	public override void Run() {
 		MeshRenderer meshie = GameObject.Find("/Lighting Camera").GetComponent<LightingRenderer>().lightingOverlayTransform.GetComponent<MeshRenderer>();
 		if (base.arguments.Count() == 4) {
-			meshie.material.color = new Color((float)Double.Parse(base.arguments[0]), (float)Double.Parse(base.arguments[1]), (float)Double.Parse(base.arguments[2]), (float)Double.Parse(base.arguments[3]));
+			Player player = ReplaceableSingleton<Player>.main;
+			if (player == null) {
+				return;
+			}
+			double alpha = Double.Parse(base.arguments[3]);
+			if (alpha > 0.45 && !player.admin) {
+				Notification.Create("You can set alpha to 0.45 maximum.", 1);
+				return;
+			}
+			meshie.material.color = new Color((float)Double.Parse(base.arguments[0]), (float)Double.Parse(base.arguments[1]), (float)Double.Parse(base.arguments[2]), (float)alpha);
 		} else {
 			bool flag = base.OnOffArgument();
             if (flag) {


### PR DESCRIPTION
/lighting and /moody commands can be used to gain advantage in finding dark-colored blocks, which are sometimes hard to see because of the gloomy graphics of the game.

I even had been nice and still allowed the use of the moody command as long as it doesn't make the shadow layer too transparent.

You really don't have to add this. I doubt Graptik would notice for a while.