### PR TITLE
Make next level xp same as the max level xp on maxed level

### DIFF
--- a/Base/Player.level.cs
+++ b/Base/Player.level.cs
@@ -1,0 +1,13 @@
+public int level {
+    get {
+        return default(int);
+    }
+    set {
+        this._level = value;
+        this.xpForCurrentLevel = this.XpForLevel(this.level);
+        int maxLevel = Config.main.data.GetInt("max_level", 100);
+        this.xpForNextLevel = this.XpForLevel((this.level >= maxLevel) ? this.level : (this.level + 1));
+        Messenger.Broadcast<int>("playerLevelChanged", this.level);
+        Messenger.Broadcast<int, int>("playerXpChanged", this.xp, this.xpForNextLevel);
+    }
+}


### PR DESCRIPTION
Now that we capped the XP server-side, it looks weird when the player is no longer gaining XP yet the XP needed for next level still appears ahead.

The new code reads the top-level max_level item from the config if possible, and handles the case when the level is max, so things are no longer confusing for the player.