### PR TITLE
Add null check to the AudioManager ExternalMusicLoader volume change

### DIFF
--- a/Base/AudioManager.OnSettingChanged().cs
+++ b/Base/AudioManager.OnSettingChanged().cs
@@ -3,7 +3,9 @@
 			if (!(name == "sfxVolume")) {
 				if (name == "musicVolume") {
 					this.SetVolume("musicVolume", val);
-					ExternalMusicLoader.instance.controller.volume = val;
+					if (ExternalMusicLoader.instance != null) {
+						ExternalMusicLoader.instance.controller.volume = val;
+					}
 				}
 			} else {
 				this.SetVolume("sfxVolume", val);


### PR DESCRIPTION
This was preventing the settings menu from being displayed properly, so it is important.